### PR TITLE
Fixing the command output

### DIFF
--- a/lib/sensu-wrapper/base.rb
+++ b/lib/sensu-wrapper/base.rb
@@ -22,7 +22,7 @@ module SensuWrapper
 
       sensu_hash = {
         "name" => cli.name,
-        "command" => cli.name,
+        "command" => cli.command,
         "status" => command_result,
         "output" => check.output,
         "handler" => cli.handler,


### PR DESCRIPTION
For some reason it was set to the name of the check,
rather than the cmd run

Some tests would really help with this :)
